### PR TITLE
Arguments join by Vital.System.

### DIFF
--- a/autoload/unified_diff.vim
+++ b/autoload/unified_diff.vim
@@ -73,7 +73,7 @@ function! unified_diff#diff(fname_in, fname_new) abort " {{{
     call extend(args, g:unified_diff#iwhite_arguments)
   endif
   call extend(args, [a:fname_in, a:fname_new])
-  let unified = s:P.system(join(args))
+  let unified = s:P.system(args)
   return s:parse_unified(unified)
 endfunction " }}}
 function! unified_diff#diffexpr() abort " {{{


### PR DESCRIPTION
windows下では`v:fname_in`等が`\`区切りで来ていて、
`vimproc`が導入済みの場合にエスケープ文字と認識する為か正常に動作しませんでした

`Vital.System`でリストで渡した際に、色々宜しくescapeしている処理が
見受けられたのでそちらに任せるように変更してみました
https://github.com/lambdalisue/vim-unified-diff/blob/master/autoload/vital/_unified_diff/Process.vim#L141-L142

しかし現在私の方で他OSの準備が出来なかった為、
他OSでの`vimproc`有無での確認は行えておりません
#### 確認環境

7.4.763+kaoriya win7x64 (`vimproc`有)
7.4.763+kaoriya win7x64 (`vimproc`無)
