### PR TITLE
Fix typos on the default value for iwhite_arguments option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let unified_diff#arguments = [
       \   'diff', '--no-index', '--no-color', '--no-ext-diff', '--unified=0',
       \ ]
 let unified_diff#iwhite_arguments = [
-      \   '--ignore--all-space',
+      \   '--ignore-all-space',
       \ ]
 ```
 

--- a/plugin/unified_diff.vim
+++ b/plugin/unified_diff.vim
@@ -20,7 +20,7 @@ let s:settings = {
       \   '--histogram',
       \ ],
       \ 'iwhite_arguments': [
-      \   '--ignore--all-space',
+      \   '--ignore-all-space',
       \ ],
       \}
 function! s:init() " {{{


### PR DESCRIPTION
Hi,
It seems that there is an extra hyphen in the default value of iwhite_arguments option.
I have confirmed the default value was not working with git 2.10.1. and removing the hyphen was working.

Could you take a look.

Thank you
